### PR TITLE
Bump Kombu version to 3.0.30

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ billiard==3.3.0.19
 blinker==1.3
 celery==3.1.17
 itsdangerous==0.24
-kombu==3.0.24
+kombu==3.0.30
 pytz==2014.10
 redis==2.10.3


### PR DESCRIPTION
Allows flask-celery project to run out-of-the-box with Python 2.7.11.

Closes #8.

See also celery/kombu#545.
