### PR TITLE
Fix problem with error in Celery 4: Object of type 'Message' is not JSON serializable

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,8 +32,10 @@ celery.conf.update(app.config)
 
 
 @celery.task
-def send_async_email(msg):
+def send_async_email(msgd):
     """Background task to send an email with Flask-Mail."""
+    msg = Message(msgd['subject'], sender=app.config['MAIL_DEFAULT_SENDER'], recipients=[msgd['to']])
+    msg.body = 'This is a test email sent from a background Celery task.'
     with app.app_context():
         mail.send(msg)
 
@@ -66,17 +68,16 @@ def index():
     email = request.form['email']
     session['email'] = email
 
+    subject = "Hello From Flask"
+    msgd = {'to': request.form['email'], 'subject': subject}
     # send the email
-    msg = Message('Hello from Flask',
-                  recipients=[request.form['email']])
-    msg.body = 'This is a test email sent from a background Celery task.'
     if request.form['submit'] == 'Send':
         # send right away
-        send_async_email.delay(msg)
+        send_async_email.delay(msgd)
         flash('Sending email to {0}'.format(email))
     else:
         # send in one minute
-        send_async_email.apply_async(args=[msg], countdown=60)
+        send_async_email.apply_async(args=[msgd], countdown=60)
         flash('An email will be sent to {0} in one minute'.format(email))
 
     return redirect(url_for('index'))


### PR DESCRIPTION
In Celery 4, the default serialization format was changed to JSON, so the error here is that there is no way to serialize the Message object in JSON format.